### PR TITLE
Bound movie detail cache inputs

### DIFF
--- a/app/api/movie/[id]/route.ts
+++ b/app/api/movie/[id]/route.ts
@@ -1,18 +1,22 @@
 import type { NextRequest } from "next/server";
+import { movieIdParamSchema, regionSchema } from "@/features/picker/contracts";
 import { getMovieDetail } from "@/lib/tmdb/movie-detail";
 import { NO_STORE_HEADERS, SAFE_GET_CACHE_HEADERS } from "@/lib/http/cache";
 
 export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
-  const numericId = Number(id);
-  const region = request.nextUrl.searchParams.get("region") ?? "US";
+  const movieId = movieIdParamSchema.safeParse(id);
+  const region = regionSchema.safeParse(request.nextUrl.searchParams.get("region") ?? "US");
 
-  if (!Number.isFinite(numericId)) {
-    return Response.json({ error: "invalid_payload", message: "Movie id must be numeric." }, { status: 400, headers: NO_STORE_HEADERS });
+  if (!movieId.success || !region.success) {
+    return Response.json(
+      { error: "invalid_payload", message: "Movie id and region must be valid." },
+      { status: 400, headers: NO_STORE_HEADERS },
+    );
   }
 
   try {
-    const payload = await getMovieDetail(numericId, region);
+    const payload = await getMovieDetail(movieId.data, region.data);
     return Response.json(payload, { status: 200, headers: SAFE_GET_CACHE_HEADERS });
   } catch {
     return Response.json({ error: "not_found", message: "Movie detail is unavailable." }, { status: 404, headers: NO_STORE_HEADERS });

--- a/app/movie/[id]/page.tsx
+++ b/app/movie/[id]/page.tsx
@@ -4,7 +4,7 @@ import { notFound } from "next/navigation";
 import { PageShell } from "@/components/page-shell";
 import { MovieDetail } from "@/components/movie/movie-detail";
 import { getMovieDetail } from "@/lib/tmdb/movie-detail";
-import { regionSchema } from "@/features/picker/contracts";
+import { movieIdParamSchema, regionSchema } from "@/features/picker/contracts";
 
 async function loadMovieDetail(id: number, region: string) {
   try {
@@ -23,13 +23,13 @@ export default async function MoviePage({
 }) {
   const [{ id }, query] = await Promise.all([params, searchParams]);
   const region = regionSchema.safeParse(query.region ?? "US");
-  const movieId = Number(id);
+  const movieId = movieIdParamSchema.safeParse(id);
 
-  if (!region.success || !Number.isInteger(movieId) || movieId <= 0) {
+  if (!region.success || !movieId.success) {
     notFound();
   }
 
-  const detail = await loadMovieDetail(movieId, region.data);
+  const detail = await loadMovieDetail(movieId.data, region.data);
 
   if (!detail) {
     return (

--- a/components/movie/tmdb-image.tsx
+++ b/components/movie/tmdb-image.tsx
@@ -7,5 +7,7 @@ type TmdbImageProps = Omit<ImageProps, "unoptimized">;
  * transformation pipeline while retaining next/image layout and lazy loading.
  */
 export function TmdbImage(props: TmdbImageProps) {
-  return <Image {...props} unoptimized />;
+  const unoptimized = typeof props.src === "string" && props.src.startsWith("https://image.tmdb.org/t/p/");
+
+  return <Image {...props} unoptimized={unoptimized} />;
 }

--- a/features/picker/contracts.ts
+++ b/features/picker/contracts.ts
@@ -47,6 +47,13 @@ export const regionSchema = z
   .regex(/^[A-Z]{2}$/)
   .default("US");
 
+export const movieIdParamSchema = z
+  .string()
+  .trim()
+  .regex(/^[1-9]\d*$/)
+  .transform(Number)
+  .pipe(z.number().int().safe().positive());
+
 export const genreSchema = z.enum(genreValues).default("any");
 const vibeSchema = z.enum(vibeValues).default("any");
 const availabilityModeSchema = z.enum(availabilityValues).default("subscription");

--- a/lib/tmdb/images.ts
+++ b/lib/tmdb/images.ts
@@ -1,4 +1,4 @@
-export function buildTmdbImageUrl(path: string | null | undefined, size: "w300" | "w500" | "w780" | "original" = "w500") {
+export function buildTmdbImageUrl(path: string | null | undefined, size: "w300" | "w500" | "w780" = "w500") {
   if (!path) {
     return undefined;
   }

--- a/tests/unit/movie-route.test.ts
+++ b/tests/unit/movie-route.test.ts
@@ -1,0 +1,54 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { getMovieDetail } = vi.hoisted(() => ({
+  getMovieDetail: vi.fn(async (_id: number, region: string) => ({
+    movie: { card: { id: 550, title: "Fight Club" } },
+    meta: { region, source: "live_tmdb" },
+  })),
+}));
+
+vi.mock("@/lib/tmdb/movie-detail", () => ({ getMovieDetail }));
+
+import { GET } from "@/app/api/movie/[id]/route";
+
+function request(id: string, region?: string) {
+  const url = new URL(`http://localhost/api/movie/${id}`);
+  if (region !== undefined) url.searchParams.set("region", region);
+
+  return GET(new NextRequest(url), { params: Promise.resolve({ id }) });
+}
+
+describe("GET /api/movie/[id]", () => {
+  beforeEach(() => {
+    getMovieDetail.mockClear();
+  });
+
+  it.each(["0", "-1", "1.5", "abc", "0x10", "9007199254740992"])(
+    "rejects the noncanonical movie id %s before fetching",
+    async (id) => {
+      const response = await request(id);
+
+      expect(response.status).toBe(400);
+      expect(response.headers.get("Cache-Control")).toContain("no-store");
+      expect(getMovieDetail).not.toHaveBeenCalled();
+    },
+  );
+
+  it("rejects an invalid region before fetching", async () => {
+    const response = await request("550", "USA");
+
+    expect(response.status).toBe(400);
+    expect(getMovieDetail).not.toHaveBeenCalled();
+  });
+
+  it("normalizes a valid region and returns a shared-cacheable response", async () => {
+    const response = await request("550", " gb ");
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe(
+      "public, s-maxage=900, stale-while-revalidate=86400",
+    );
+    expect(getMovieDetail).toHaveBeenCalledWith(550, "GB");
+  });
+});

--- a/tests/unit/resource-usage.test.tsx
+++ b/tests/unit/resource-usage.test.tsx
@@ -1,10 +1,21 @@
 import { renderToStaticMarkup } from "react-dom/server";
+import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 import { TmdbImage } from "@/components/movie/tmdb-image";
 import { SAFE_GET_CACHE_HEADERS } from "@/lib/http/cache";
 import { buildTmdbImageUrl } from "@/lib/tmdb/images";
 
 describe("low-resource delivery", () => {
+  it("disables deployment for every unspecified branch, including names with slashes", () => {
+    const config = JSON.parse(readFileSync("vercel.json", "utf8"));
+
+    expect(config.git.deploymentEnabled).toEqual({
+      "**": false,
+      master: true,
+      "release/**": true,
+    });
+  });
+
   it("renders TMDB media directly instead of through Vercel image optimization", () => {
     const source = buildTmdbImageUrl("/poster.jpg", "w500");
     const markup = renderToStaticMarkup(
@@ -13,6 +24,14 @@ describe("low-resource delivery", () => {
 
     expect(markup).toContain("https://image.tmdb.org/t/p/w500/poster.jpg");
     expect(markup).not.toContain("/_next/image");
+  });
+
+  it("retains normal Next.js optimization for non-TMDB media", () => {
+    const markup = renderToStaticMarkup(
+      <TmdbImage src="/local-poster.jpg" alt="Local poster" width={500} height={750} />,
+    );
+
+    expect(markup).toContain("/_next/image");
   });
 
   it("keeps safe GET responses fresh briefly and reusable while revalidating", () => {

--- a/vercel.json
+++ b/vercel.json
@@ -3,7 +3,7 @@
   "fluid": true,
   "git": {
     "deploymentEnabled": {
-      "*": false,
+      "**": false,
       "master": true,
       "release/**": true
     }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,6 +10,6 @@ export default defineConfig({
   test: {
     environment: "happy-dom",
     setupFiles: ["tests/setup/happy-dom.ts"],
-    include: ["tests/unit/**/*.test.ts"],
+    include: ["tests/unit/**/*.test.{ts,tsx}"],
   },
 });


### PR DESCRIPTION
## Summary\n- centralize canonical positive TMDB movie ID parsing\n- normalize and validate movie-detail regions before origin access\n- reject invalid cache-key inputs with no-store responses\n- change the Vercel deny glob from `*` to `**` so slash-named feature branches are also excluded\n- restore discovery of TSX resource-usage regressions and pin the deployment contract\n\n## Verification\n- pnpm run check (9 files, 28 tests)\n- pnpm run docs:check\n- pnpm run audit:high\n- follow-up push created no Vercel deployment